### PR TITLE
Multi file generation

### DIFF
--- a/pydoc-markdown/package.yaml
+++ b/pydoc-markdown/package.yaml
@@ -62,6 +62,7 @@ entrypoints:
     - hugo = pydoc_markdown.contrib.renderers.hugo:HugoRenderer
     - markdown = pydoc_markdown.contrib.renderers.markdown:MarkdownRenderer
     - mkdocs = pydoc_markdown.contrib.renderers.mkdocs:MkdocsRenderer
+    - docusaurus = pydoc_markdown.contrib.renderers.docusaurus:DocusaurusRenderer
   pydoc_markdown.interfaces.SourceLinker:
     - github = pydoc_markdown.contrib.source_linkers.github:GitHubSourceLinker
 

--- a/pydoc-markdown/setup.py
+++ b/pydoc-markdown/setup.py
@@ -63,6 +63,7 @@ setuptools.setup(
       'hugo = pydoc_markdown.contrib.renderers.hugo:HugoRenderer',
       'markdown = pydoc_markdown.contrib.renderers.markdown:MarkdownRenderer',
       'mkdocs = pydoc_markdown.contrib.renderers.mkdocs:MkdocsRenderer',
+      'docusaurus = pydoc_markdown.contrib.renderers.docusaurus:DocusaurusRenderer',
     ],
     'pydoc_markdown.interfaces.SourceLinker': [
       'github = pydoc_markdown.contrib.source_linkers.github:GitHubSourceLinker',

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -68,10 +68,12 @@ class DocusaurusRenderer(MarkdownRenderer):
     module_tree = {"children": {}, "edges": []}
     output_path = Path(self.docs_base_path) / self.relative_output_path
     for module in modules:
-      module_parts = module.name.split(".")
       filepath = output_path
+
+      module_parts = module.name.split(".")
       relative_module_tree = module_tree
       intermediary_module = []
+
       for module_part in module_parts[:-1]:
         # update the module tree
         intermediary_module.append(module_part)

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -7,6 +7,7 @@ from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
 from typing import Any, Dict, List, Text
 import docspec
 import json
+import os.path
 
 
 @implements(Renderer)
@@ -45,8 +46,14 @@ class DocusaurusRenderer(MarkdownRenderer):
   escape_html_in_docstring = Field(bool, default=True)
 
   def _render_header(self, fp, level, obj):
-    # TODO: render docusaurus header
-    return super(DocusaurusRenderer, self)._render_header(fp, level, obj)
+    if isinstance(obj, docspec.Module):
+      fp.write('---\n')
+      fp.write(f'sidebar_label: {obj.name}\n')
+      fp.write(f'title: {obj.name}\n')
+      fp.write('---\n\n')
+      return
+
+    super(DocusaurusRenderer, self)._render_header(fp, level, obj)
 
   def _render_recursive(self, fp, level, obj):
     members = getattr(obj, 'members', [])
@@ -89,7 +96,9 @@ class DocusaurusRenderer(MarkdownRenderer):
         continue
 
       # only update the relative module tree if the file is not empty
-      relative_module_tree["edges"].append(str(filepath.relative_to(self.docs_base_path)))
+      relative_module_tree["edges"].append(
+        os.path.splitext(str(filepath.relative_to(self.docs_base_path)))[0]
+      )
 
     self._render_side_bar_config(module_tree)
 

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -13,9 +13,8 @@ import os.path
 @implements(Renderer)
 class DocusaurusRenderer(MarkdownRenderer):
   """
-  Produces Markdown files. This renderer is often used by other renderers, such as
-  #MkdocsRenderer and #HugoRenderer. It provides a wide variety of options to customize
-  the generated Markdown files.
+  Produces Markdown files to be used with Docusaurus websites.
+  It inherits #MarkdownRenderer and provides nice defaults.
 
   ### Options
   """

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -1,0 +1,85 @@
+# -*- coding: utf8 -*-
+# Copyright (c) 2019 Niklas Rosenstein
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from docspec_python import format_arglist
+from nr.databind.core import Field, Struct, Validator
+from nr.interface import implements, override
+from pathlib import Path
+from pydoc_markdown.interfaces import Context, Renderer, Resolver, SourceLinker
+from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
+from typing import Iterable, List, Optional, TextIO
+import docspec
+import html
+import io
+import sys
+
+
+@implements(Renderer)
+class DocusaurusRenderer(MarkdownRenderer):
+  """
+  Produces Markdown files. This renderer is often used by other renderers, such as
+  #MkdocsRenderer and #HugoRenderer. It provides a wide variety of options to customize
+  the generated Markdown files.
+
+  ### Options
+  """
+
+  #: If enabled, inserts anchors before Markdown headers to ensure that
+  #: links to the header work. This is disabled by default because Docusaurus
+  #: supports this automatically.
+  insert_header_anchors = Field(bool, default=False)
+
+  #: The path where to write the multiple docs files,
+  #: when `render_multiple_files` is True. Defaults to the
+  #: current working directory.
+  output_path = Field(str, default='.')
+
+  #: Skip documenting modules if empty. Defaults to True.
+  skip_empty_modules = Field(bool, default=True)
+
+  #: Escape html in docstring. Default to True.
+  escape_html_in_docstring = Field(bool, default=True)
+
+  def _render_header(self, fp, level, obj):
+    # TODO: render docusaurus header
+    return super(DocusaurusRenderer, self)._render_header(fp, level, obj)
+
+  def _render_recursive(self, fp, level, obj):
+    members = getattr(obj, 'members', [])
+    if self.skip_empty_modules and isinstance(obj, docspec.Module) and not members:
+      return
+
+    return super(DocusaurusRenderer, self)._render_recursive(fp, level, obj)
+
+  @override
+  def render(self, modules: List[docspec.Module]) -> None:
+    for module in modules:
+      module_parts = module.name.split(".")
+      filepath = Path(self.output_path)
+      for module_part in module_parts[:-1]:
+        filepath = filepath / module_part
+
+      filepath.mkdir(parents=True, exist_ok=True)
+      filepath = filepath / f"{module_parts[-1]}.md"
+      with filepath.open('w', encoding=self.encoding) as fp:
+        self._render_modules([module], fp)
+      if self.skip_empty_modules and not filepath.read_text():
+        filepath.unlink()

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -22,7 +22,6 @@
 from docspec_python import format_arglist
 from nr.databind.core import Field, Struct, Validator
 from nr.interface import implements, override
-from pathlib import Path
 from pydoc_markdown.interfaces import Context, Renderer, Resolver, SourceLinker
 from typing import Iterable, List, Optional, TextIO
 import docspec

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from pydoc_markdown.interfaces import Context, Renderer, Resolver, SourceLinker
 from typing import Iterable, List, Optional, TextIO
 import docspec
+import html
 import io
 import sys
 
@@ -189,6 +190,9 @@ class MarkdownRenderer(Struct):
   #: file if a #source_linker is configured. The default is `[[view_source]]({url})`.
   source_format = Field(str, default='[[view_source]]({url})')
 
+  #: Escape html in docstring. Default to False.
+  escape_html_in_docstring = Field(bool, default=False)
+
   _reverse_map = Field(docspec.ReverseMap, default=None, hidden=True)
   def _get_parent(self, obj: docspec.ApiObject) -> Optional[docspec.ApiObject]:
     return self._reverse_map.get_parent(obj)
@@ -298,7 +302,8 @@ class MarkdownRenderer(Struct):
     if source_string and self.source_position == 'after signature':
       fp.write(source_string + '\n\n')
     if obj.docstring:
-      lines = obj.docstring.split('\n')
+      docstring = html.escape(obj.docstring) if self.escape_html_in_docstring else obj.docstring
+      lines = docstring.split('\n')
       if self.docstrings_as_blockquote:
         lines = ['> ' + x for x in lines]
       fp.write('\n'.join(lines))

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -156,17 +156,6 @@ class MarkdownRenderer(Struct):
   #: levels can be defined with #header_level_by_type.
   use_fixed_header_levels = Field(bool, default=True)
 
-  #: Render multiple files. Default to a single file.
-  render_multiple_files = Field(bool, default=False)
-
-  #: The path where to write the multiple docs files,
-  #: when `render_multiple_files` is True. Defaults to the
-  #: current working directory.
-  multiple_files_output_path = Field(str, default='.')
-
-  #: Skip documenting modules if empty
-  skip_empty_modules = Field(bool, default=False)
-
   #: Fixed header levels by API object type.
   header_level_by_type = Field({int}, default={
     'Module': 1,
@@ -310,13 +299,9 @@ class MarkdownRenderer(Struct):
       fp.write('\n\n')
 
   def _render_recursive(self, fp, level, obj):
-    members = getattr(obj, 'members', [])
-    if self.skip_empty_modules and isinstance(obj, docspec.Module) and not members:
-      return
-
     self._render_object(fp, level, obj)
     level += 1
-    for member in members:
+    for member in getattr(obj, 'members', []):
       self._render_recursive(fp, level, member)
 
   def _render_modules(self, modules: List[docspec.Module], fp: TextIO):
@@ -410,21 +395,7 @@ class MarkdownRenderer(Struct):
 
   @override
   def render(self, modules: List[docspec.Module]) -> None:
-    if self.render_multiple_files:
-      for module in modules:
-        module_parts = module.name.split(".")
-        filepath = Path(self.multiple_files_output_path)
-        for module_part in module_parts[:-1]:
-          filepath = filepath / module_part
-
-        filepath.mkdir(parents=True, exist_ok=True)
-        filepath = filepath / f"{module_parts[-1]}.md"
-        with filepath.open('w', encoding=self.encoding) as fp:
-          self._render_modules([module], fp)
-        if self.skip_empty_modules and not filepath.read_text():
-          filepath.unlink()
-
-    elif self.filename is None:
+    if self.filename is None:
       self._render_modules(modules, self.fp or sys.stdout)
     else:
       with io.open(self.filename, 'w', encoding=self.encoding) as fp:


### PR DESCRIPTION
## Proposed changes
- add `escape_html_in_docstring` option on the default `MarkdownRenderer`
- create a `DocusaurusRenderer` class that can generate multiple markdown files